### PR TITLE
Use std::io::Result type for more idiomatic error handling

### DIFF
--- a/examples/connecting.rs
+++ b/examples/connecting.rs
@@ -29,7 +29,7 @@ fn test_ftp(addr: &str, user: &str, pass: &str) -> Result<()> {
 
 fn main() {
 	test_ftp("127.0.0.1", "Doe", "mumble").unwrap_or_else(|err|
-		panic!(err)
+		panic!("{}", err)
 	);
 	println!("test successful")
 }

--- a/examples/connecting.rs
+++ b/examples/connecting.rs
@@ -1,48 +1,35 @@
 extern crate ftp;
 
 use std::str;
-use std::io::Cursor;
+use std::io::{Cursor, Error, ErrorKind, Result};
 use ftp::FtpStream;
 
-fn main() {
-	let mut ftp_stream = match FtpStream::connect("127.0.0.1", 21) {
-        Ok(s) => s,
-        Err(e) => panic!("{}", e)
-    };
+fn test_ftp(addr: &str, user: &str, pass: &str) -> Result<()> {
+	let mut ftp_stream = try!(FtpStream::connect(addr, 21));
+    try!(ftp_stream.login(user, pass));
+	println!("current dir: {}", try!(ftp_stream.current_dir()));
 
-    match ftp_stream.login("username", "password") {
-        Ok(_) => (),
-        Err(e) => panic!("{}", e)
-    }
+    try!(ftp_stream.change_dir("test_data"));
 
-    match ftp_stream.current_dir() {
-        Ok(dir) => println!("{}", dir),
-        Err(e) => panic!("{}", e)
-    }
-
-    match ftp_stream.change_dir("test_data") {
-        Ok(_) => (),
-        Err(e) => panic!("{}", e)
-    }
-
-    //An easy way to retreive a file
-    let remote_file = match ftp_stream.simple_retr("ftpext-charter.txt") {
-        Ok(file) => file,
-        Err(e) => panic!("{}", e)
-    };
-
-    match str::from_utf8(&remote_file.into_inner()) {
-        Ok(s) => print!("{}", s),
-        Err(e) => panic!("Error reading file data: {}", e)
-    };
+    //An easy way to retrieve a file
+	let cursor = try!(ftp_stream.simple_retr("ftpext-charter.txt"));
+	let vec = cursor.into_inner();
+    let text = try!(str::from_utf8(&vec).or_else(|cause|
+    	Err(Error::new(ErrorKind::Other, cause))
+    ));
+	println!("got data: {}", text);
 
     //Store a file
     let file_data = format!("Some awesome file data man!!");
-    let reader: &mut Cursor<Vec<u8>> = &mut Cursor::new(file_data.into_bytes());
-    match ftp_stream.stor("my_random_file.txt", reader) {
-        Ok(_) => (),
-        Err(e) => panic!("{}", e)
-    }
+    let mut reader = Cursor::new(file_data.into_bytes());
+    try!(ftp_stream.stor("my_random_file.txt", &mut reader));
 
-    let _ = ftp_stream.quit();
+    ftp_stream.quit()
+}
+
+fn main() {
+	test_ftp("127.0.0.1", "Doe", "mumble").unwrap_or_else(|err|
+		panic!(err)
+	);
+	println!("test successful")
 }

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -9,10 +9,9 @@
 //!
 //! ```rust
 //! use ftp::FtpStream;
-//! let mut ftp_stream = match FtpStream::connect("127.0.0.1", 21) {
-//!   Ok(s) => s,
-//!   Err(e) => panic!("{}", e)
-//! };
+//! let mut ftp_stream = FtpStream::connect("127.0.0.1", 21).unwrap_or_else(|err|
+//!     panic!("{}", err)
+//! );
 //! let _ = ftp_stream.quit();
 //! ```
 //!

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -20,9 +20,8 @@
 
 extern crate regex;
 
-use std::io::{Error, ErrorKind, Read, BufReader, BufWriter , Cursor, Write, copy};
+use std::io::{Error, ErrorKind, Read, Result, BufReader, BufWriter , Cursor, Write, copy};
 use std::net::TcpStream;
-use std::result::Result;
 use std::string::String;
 use std::str::FromStr;
 use regex::Regex;
@@ -38,7 +37,7 @@ pub struct FtpStream {
 impl FtpStream {
 
 	/// Creates an FTP Stream.
-	pub fn connect<S: Into<String>>(host: S, port: u16) -> Result<FtpStream, Error> {
+	pub fn connect<S: Into<String>>(host: S, port: u16) -> Result<FtpStream> {
         let host_string = host.into();
 		let connect_string = format!("{}:{}", host_string, port);
 		let tcp_stream = try!(TcpStream::connect(&*connect_string));
@@ -47,76 +46,48 @@ impl FtpStream {
 			host: host_string,
 			command_port: port
 		};
-		match ftp_stream.read_response(220) {
-			Ok(_) => (),
-			Err(e) => return Err(Error::new(ErrorKind::Other, e))
-		}
+		
+		try!(ftp_stream.read_response(220));
 		Ok(ftp_stream)
 	}
 
-	fn write_str(&mut self, s: &str) -> Result<(), Error> {
+	fn write_str(&mut self, s: &str) -> Result<()> {
 		return self.command_stream.write_fmt(format_args!("{}", s));
 	}
 
 	/// Log in to the FTP server.
-	pub fn login(&mut self, user: &str, password: &str) -> Result<(), String> {
+	pub fn login(&mut self, user: &str, password: &str) -> Result<()> {
 		let user_command = format!("USER {}\r\n", user);
-		let pass_command = format!("PASS {}\r\n", password);
-
-		match self.write_str(&user_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(331) {
-			Ok(_) => {
-
-				match self.write_str(&pass_command) {
-					Ok(_) => (),
-					Err(_) => return Err(format!("Write Error"))
-				}
-
-				match self.read_response(230) {
-					Ok(_) => Ok(()),
-					Err(s) => Err(s)
-				}
-			},
-			Err(s) => Err(s)
-		}
+		try!(self.write_str(&user_command));
+		
+		self.read_response(331).and_then(|_| {
+			let pass_command = format!("PASS {}\r\n", password);
+			try!(self.write_str(&pass_command));
+			try!(self.read_response(230));
+			Ok(())
+		})
 	}
 
 	/// Change the current directory to the path specified.
-	pub fn change_dir(&mut self, path: &str) -> Result<(), String> {
+	pub fn change_dir(&mut self, path: &str) -> Result<()> {
 		let cwd_command = format!("CWD {}\r\n", path);
 
-		match self.write_str(&cwd_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(250) {
-			Ok(_) => Ok(()),
-			Err(e) => Err(e)
-		}
+		try!(self.write_str(&cwd_command));
+		try!(self.read_response(250));
+		Ok(())
 	}
 
 	/// Move the current directory to the parent directory.
-	pub fn change_dir_to_parent(&mut self) -> Result<(), String> {
+	pub fn change_dir_to_parent(&mut self) -> Result<()> {
 		let cdup_command = format!("CDUP\r\n");
 
-		match self.write_str(&cdup_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(250) {
-			Ok(_) => Ok(()),
-			Err(s) => Err(s)
-		}
+		try!(self.write_str(&cdup_command));
+		try!(self.read_response(250));
+		Ok(())
 	}
 
 	/// Gets the current directory
-	pub fn current_dir(&mut self) -> Result<String, String> {
+	pub fn current_dir(&mut self) -> Result<String> {
 		fn index_of(string: &str, ch: char) -> isize {
 			let mut i = -1;
 			let mut index = 0;
@@ -141,68 +112,45 @@ impl FtpStream {
 			}
 			return i;
 		}
+		
 		let pwd_command = format!("PWD\r\n");
 
-		match self.write_str(&pwd_command) {
-			Ok(_) => (),
-			Err(e) => return Err(format!("{}", e))
-		}
+		try!(self.write_str(&pwd_command));
+		self.read_response(257).and_then(|(_, line)| {
+			let begin = index_of(&line, '"');
+			let end = last_index_of(&line, '"');
 
-		match self.read_response(257) {
-			Ok((_, line)) => {
-				let begin = index_of(&line, '"');
-				let end = last_index_of(&line, '"');
+			if begin == -1 || end == -1 {
+				let cause = format!("Invalid PWD Response: {}", line);
+				return Err(Error::new(ErrorKind::Other, cause))
+			}
+			let b = begin as usize;
+			let e = end as usize;
 
-				if begin == -1 || end == -1 {
-					return Err(format!("Invalid PWD Response: {}", line))
-				}
-				let b = begin as usize;
-				let e = end as usize;
-
-				return Ok(line[b+1..e].to_string())
-			},
-			Err(e) => Err(e)
-		}
+			return Ok(line[b+1..e].to_string())
+		})
 	}
 
 	/// This does nothing. This is usually just used to keep the connection open.
-	pub fn noop(&mut self) -> Result<(), String> {
+	pub fn noop(&mut self) -> Result<()> {
 		let noop_command = format!("NOOP\r\n");
-
-		match self.write_str(&noop_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(200) {
-			Ok(_) => Ok(()),
-			Err(s) => Err(s)
-		}
+		try!(self.write_str(&noop_command));
+		try!(self.read_response(200));
+		Ok(())
 	}
 
 	/// This creates new directories on the server.
-	pub fn make_dir(&mut self, pathname: &str) -> Result<(), String> {
+	pub fn make_dir(&mut self, pathname: &str) -> Result<()> {
 		let mkdir_command = format!("MKD {}\r\n", pathname);
-
-		match self.write_str(&mkdir_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(257) {
-			Ok(_) => Ok(()),
-			Err(e) => Err(e)
-		}
+		try!(self.write_str(&mkdir_command));
+		try!(self.read_response(257));
+		Ok(())
 	}
 
 	/// Runs the PASV command.
-	pub fn pasv(&mut self) -> Result<(isize), String> {
+	pub fn pasv(&mut self) -> Result<isize> {
 		let pasv_command = format!("PASV\r\n");
-
-		match self.write_str(&pasv_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
+		try!(self.write_str(&pasv_command));
 
 		//PASV response format : 227 Entering Passive Mode (h1,h2,h3,h4,p1,p2).
 
@@ -211,65 +159,45 @@ impl FtpStream {
     		Err(_) => panic!("Invaid Regex!!"),
 		};
 
-		match self.read_response(227) {
-			Ok((_, line)) => {
-				let caps = response_regex.captures(&line).unwrap();
-				let caps_2 = match caps.at(2) {
-					Some(s) => s,
-					None => return Err(format!("Problems parsing reponse"))
-				};
-				let caps_3 = match caps.at(3) {
-					Some(s) => s,
-					None => return Err(format!("Problems parsing reponse"))
-				};
-				let first_part_port: isize = FromStr::from_str(caps_2).unwrap();
-				let second_part_port: isize = FromStr::from_str(caps_3).unwrap();
-				Ok((first_part_port*256)+second_part_port)
-			},
-			Err(s) => Err(s)
-		}
+		self.read_response(227).and_then(|(_, line)| {
+			let caps = response_regex.captures(&line).unwrap();
+			let caps_2 = match caps.at(2) {
+				Some(s) => s,
+				None => return Err(Error::new(ErrorKind::Other, "Problems parsing reponse"))
+			};
+			let caps_3 = match caps.at(3) {
+				Some(s) => s,
+				None => return Err(Error::new(ErrorKind::Other, "Problems parsing reponse"))
+			};
+			let first_part_port: isize = FromStr::from_str(caps_2).unwrap();
+			let second_part_port: isize = FromStr::from_str(caps_3).unwrap();
+			Ok((first_part_port*256)+second_part_port)
+		})
 	}
 
 	/// Quits the current FTP session.
-	pub fn quit(&mut self) -> Result<(isize, String), String> {
+	pub fn quit(&mut self) -> Result<(isize, String)> {
 		let quit_command = format!("QUIT\r\n");
-
-		match self.write_str(&quit_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(221) {
-			Ok((code, message)) => Ok((code, message)),
-			Err(message) => Err(message),
-		}
+		try!(self.write_str(&quit_command));
+		self.read_response(221)
 	}
 
 	/// Retrieves the file name specified from the server. This method is a more complicated way to retrieve a file. The reader returned should be dropped.
 	/// Also you will have to read the response to make sure it has the correct value.
-	pub fn retr(&mut self, file_name: &str) -> Result<BufReader<TcpStream>, String> {
+	pub fn retr(&mut self, file_name: &str) -> Result<BufReader<TcpStream>> {
 		let retr_command = format!("RETR {}\r\n", file_name);
-
-		let port = match self.pasv() {
-			Ok(p) => p,
-			Err(e) => return Err(e)
-		};
+		let port = try!(self.pasv());
 
 		let connect_string = format!("{}:{}", self.host, port);
 		let data_stream = BufReader::new(TcpStream::connect(&*connect_string).unwrap());
 
-		match self.write_str(&retr_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(150) {
-			Ok(_) => Ok(data_stream),
-			Err(e) => Err(e)
-		}
+		try!(self.write_str(&retr_command));
+		self.read_response(150).and_then(|_| {
+			Ok(data_stream)
+		})
 	}
 
-	fn simple_retr_(&mut self, file_name: &str) -> Result<Cursor<Vec<u8>>, String> {
+	fn simple_retr_(&mut self, file_name: &str) -> Result<Cursor<Vec<u8>>> {
 		let mut data_stream = match self.retr(file_name) {
 			Ok(s) => s,
 			Err(e) => return Err(e)
@@ -278,18 +206,11 @@ impl FtpStream {
 		let buffer: &mut Vec<u8> = &mut Vec::new();
 		loop {
 			let mut buf = [0; 256];
-			let len = match data_stream.read(&mut buf) {
-            	Ok(len) => len,
-            	//Err(ref e) if e.kind == EndOfFile => break,
-            	Err(e) => return Err(format!("{}", e)),
-        	};
+			let len = try!(data_stream.read(&mut buf));
         	if len == 0 {
 				break;
 			}
-        	match buffer.write(&buf[0..len]) {
-        		Ok(_) => (),
-        		Err(e) => return Err(format!("{}", e))
-        	};
+        	try!(buffer.write(&buf[0..len]));
 		}
 
 		drop(data_stream);
@@ -298,81 +219,43 @@ impl FtpStream {
 	}
 
 	/// Simple way to retr a file from the server. This stores the file in memory.
-	pub fn simple_retr(&mut self, file_name: &str) -> Result<Cursor<Vec<u8>>, String> {
-		let r = match self.simple_retr_(file_name) {
-			Ok(reader) => reader,
-			Err(e) => return Err(e)
-		};
-
-		match self.read_response(226) {
-			Ok(_) => Ok(r),
-			Err(e) => Err(e)
-		}
+	pub fn simple_retr(&mut self, file_name: &str) -> Result<Cursor<Vec<u8>>> {
+		let r = try!(self.simple_retr_(file_name));
+		try!(self.read_response(226));
+		Ok(r)
 	}
 
 	/// Removes the remote pathname from the server.
-	pub fn remove_dir(&mut self, pathname: &str) -> Result<(), String> {
+	pub fn remove_dir(&mut self, pathname: &str) -> Result<()> {
 		let rmd_command = format!("RMD {}\r\n", pathname);
-
-		match self.write_str(&rmd_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
-
-		match self.read_response(250) {
-			Ok(_) => Ok(()),
-			Err(e) => Err(e)
-		}
+		try!(self.write_str(&rmd_command));
+		try!(self.read_response(250));
+		Ok(())
 	}
 
-	fn stor_<R: Read>(&mut self, filename: &str, r: &mut R) -> Result<(), String> {
+	fn stor_<R: Read>(&mut self, filename: &str, r: &mut R) -> Result<()> {
 		let stor_command = format!("STOR {}\r\n", filename);
-
-		let port = match self.pasv() {
-			Ok(p) => p,
-			Err(e) => return Err(e)
-		};
+		let port = try!(self.pasv());
 
 		let connect_string = format!("{}:{}", self.host, port);
 		let data_stream: &mut BufWriter<TcpStream> = &mut BufWriter::new(TcpStream::connect(&*connect_string).unwrap());
 
-		match self.write_str(&stor_command) {
-			Ok(_) => (),
-			Err(_) => return Err(format!("Write Error"))
-		}
+		try!(self.write_str(&stor_command));
+		try!(self.read_response(150));
 
-		match self.read_response(150) {
-			Ok(_) => (),
-			Err(e) => return Err(e)
-		}
-
-		match copy(r, data_stream) {
-			Ok(_) => {
-				drop(data_stream);
-				Ok(())
-			},
-			Err(_) => {
-				drop(data_stream);
-				Err(format!("Error Writing"))
-			}
-		}
+		try!(copy(r, data_stream));
+		Ok(())
 	}
 
 	/// This stores a file on the server.
-	pub fn stor<R: Read>(&mut self, filename: &str, r: &mut R) -> Result<(), String> {
-		match self.stor_(filename, r) {
-			Ok(_) => (),
-			Err(e) => return Err(e)
-		};
-
-		match self.read_response(226) {
-			Ok(_) => Ok(()),
-			Err(e) => Err(e)
-		}
+	pub fn stor<R: Read>(&mut self, filename: &str, r: &mut R) -> Result<()> {
+		try!(self.stor_(filename, r));
+		try!(self.read_response(226));
+		Ok(())
 	}
 
 	//Retrieve single line response
-	pub fn read_response(&mut self, expected_code: isize) -> Result<(isize, String), String> {
+	pub fn read_response(&mut self, expected_code: isize) -> Result<(isize, String)> {
 		//Carriage return
 		let cr = 0x0d;
 		//Line Feed
@@ -383,7 +266,7 @@ impl FtpStream {
 				let byte_buffer: &mut [u8] = &mut [0];
 				match self.command_stream.read(byte_buffer) {
 					Ok(_) => {},
-					Err(_) => return Err(format!("Error reading response")),
+					Err(_) => return Err(Error::new(ErrorKind::Other, "Error reading response")),
 				}
 				line_buffer.push(byte_buffer[0]);
 		}
@@ -393,14 +276,14 @@ impl FtpStream {
 		let trimmed_response = response.trim_matches(chars_to_trim);
     	let trimmed_response_vec: Vec<char> = trimmed_response.chars().collect();
     	if trimmed_response_vec.len() < 5 || trimmed_response_vec[3] != ' ' {
-    		return Err(format!("Invalid response"));
+    		return Err(Error::new(ErrorKind::Other, "Invalid response"));
     	}
 
     	let v: Vec<&str> = trimmed_response.splitn(2, ' ').collect();
     	let code: isize = FromStr::from_str(v[0]).unwrap();
     	let message = v[1];
     	if code != expected_code {
-    		return Err(format!("Invalid response: {} {}", code, message))
+    		return Err(Error::new(ErrorKind::Other, format!("Invalid response: {} {}", code, message)))
     	}
     	Ok((code, message.to_string()))
 	}

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -176,10 +176,11 @@ impl FtpStream {
 	}
 
 	/// Quits the current FTP session.
-	pub fn quit(&mut self) -> Result<(isize, String)> {
+	pub fn quit(&mut self) -> Result<()> {
 		let quit_command = format!("QUIT\r\n");
 		try!(self.write_str(&quit_command));
-		self.read_response(221)
+		try!(self.read_response(221));
+		Ok(())
 	}
 
 	/// Retrieves the file name specified from the server. This method is a more complicated way to retrieve a file. The reader returned should be dropped.


### PR DESCRIPTION
Use std::io::Result instead of std::result::Result to use std::io::Error type for error reporting instead of String.

Also, rewrote the code with macro try! and Result methods (and_then, unwrap_or_else) to make the code shorter and easier to read.
